### PR TITLE
registry port is 5000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       EMAIL: "aospan@jokersys.com"
       DOMAIN: "repo.jokersys.com"
-      UPSTREAM: "registry:80"
+      UPSTREAM: "registry:5000"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
to expose your registry, the port is 5000.
By default, the smashwilson/lets-nginx not supports the option the env UPSTREAM with protocol (i.e.: "https://registry:5000").
To do that, I created a template ad hoc, a docker image that extends smashwilson/lets-nginx, and now my registry is on 443 port!
thanks for your example!!